### PR TITLE
Add deck view screen

### DIFF
--- a/backend/src/routes/decks.route.ts
+++ b/backend/src/routes/decks.route.ts
@@ -3,6 +3,7 @@ import { requireAuth } from "../middleware/auth.middleware";
 import {
   listDecks,
   getDeck,
+  getDeckDetails,
   createDeck,
   updateDeck,
   deleteDeck,
@@ -14,6 +15,7 @@ router.use(requireAuth);
 router.get("/", listDecks);
 router.post("/", createDeck);
 router.get("/:id", getDeck);
+router.get("/:id/details", getDeckDetails);
 router.put("/:id", updateDeck);
 router.delete("/:id", deleteDeck);
 

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -4,11 +4,13 @@ import { PageNotFound } from './features/page-not-found/page-not-found';
 import { AuthCallback } from './core/auth-callback/auth-callback';
 import { DeckList } from './features/deck-list/deck-list';
 import { DeckEdit } from './features/deck-edit/deck-edit';
+import { DeckView } from './features/deck-view/deck-view';
 
 export const routes: Routes = [
   { path: '', component: Home },
   { path: 'decks', component: DeckList },
   { path: 'decks/new', component: DeckEdit },
+  { path: 'decks/:id', component: DeckView },
   { path: 'decks/:id/edit', component: DeckEdit },
   { path: '**', component: PageNotFound },
   { path: 'auth/callback', component: AuthCallback },

--- a/frontend/src/app/features/deck-list/deck-list.html
+++ b/frontend/src/app/features/deck-list/deck-list.html
@@ -3,7 +3,7 @@
 <ul>
   @for (d of decks; track d.id) {
     <li>
-        <a [routerLink]="['/decks', d.id, 'edit']">{{ d.name }}</a>
+        <a [routerLink]="['/decks', d.id]">{{ d.name }}</a>
         <button (click)="delete(d.id)">Delete</button>
     </li>
   }

--- a/frontend/src/app/features/deck-view/deck-view.html
+++ b/frontend/src/app/features/deck-view/deck-view.html
@@ -1,0 +1,27 @@
+@if (deck) {
+  <h2>{{ deck.name }}</h2>
+  <p>
+    <a [routerLink]="['/decks', deck.id, 'edit']">Edit</a>
+    <a routerLink="/decks">Back to list</a>
+  </p>
+  <table>
+    <thead>
+      <tr>
+        <th>Qty</th>
+        <th>Name</th>
+        <th>Set</th>
+        <th>No.</th>
+      </tr>
+    </thead>
+    <tbody>
+      @for (c of deck.cards; track c.set + c.number) {
+        <tr>
+          <td>{{ c.quantity }}</td>
+          <td>{{ c.name }}</td>
+          <td>{{ c.set }}</td>
+          <td>{{ c.number }}</td>
+        </tr>
+      }
+    </tbody>
+  </table>
+}

--- a/frontend/src/app/features/deck-view/deck-view.ts
+++ b/frontend/src/app/features/deck-view/deck-view.ts
@@ -1,0 +1,21 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { CommonModule } from '@angular/common';
+import { DeckDetails, Decks } from '../../services/decks';
+
+@Component({
+  selector: 'app-deck-view',
+  imports: [CommonModule, RouterLink],
+  templateUrl: './deck-view.html',
+  styleUrl: './deck-view.scss',
+})
+export class DeckView implements OnInit {
+  deck?: DeckDetails;
+
+  constructor(private deckService: Decks, private route: ActivatedRoute) {}
+
+  ngOnInit(): void {
+    const id = this.route.snapshot.paramMap.get('id')!;
+    this.deckService.details(id).subscribe({ next: (d) => (this.deck = d) });
+  }
+}

--- a/frontend/src/app/services/decks.ts
+++ b/frontend/src/app/services/decks.ts
@@ -9,6 +9,19 @@ export interface Deck {
   content: string;
 }
 
+export interface DeckCard {
+  quantity: number;
+  name: string;
+  set: string;
+  number: string;
+}
+
+export interface DeckDetails {
+  id: number;
+  name: string;
+  cards: DeckCard[];
+}
+
 @Injectable({
   providedIn: 'root',
 })
@@ -40,6 +53,12 @@ export class Decks {
 
   delete(id: string): Observable<void> {
     return this.http.delete<void>(`${this.base}/${id}`, {
+      withCredentials: true,
+    });
+  }
+
+  details(id: string): Observable<DeckDetails> {
+    return this.http.get<DeckDetails>(`${this.base}/${id}/details`, {
       withCredentials: true,
     });
   }


### PR DESCRIPTION
## Summary
- add new GET `/decks/:id/details` endpoint returning cards with names
- display deck link in deck list
- add deck view component for frontend with table of card details
- expose `details` method in deck service
- register deck view route

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68578523afa0832cb999c17b30474e9b